### PR TITLE
Added 2019 Population data and ISO3C country codes

### DIFF
--- a/R/covid_graphs.R
+++ b/R/covid_graphs.R
@@ -1,5 +1,5 @@
-#' Generate grawth rate graph
-#' @param data data fram with colum `region` for each group, `Date` with dates and `total`, for fitting the growth rates
+#' Generate growth rate graph
+#' @param data data fram with column `region` for each group, `Date` with dates and `total`, for fitting the growth rates
 #' @param window_width width for rolling window
 #' @return a `ggplot` object
 #' @export
@@ -53,8 +53,8 @@ growth_rate_graph <- function(data,window_width){
 }
 
 
-#' Generate grawth rate graph
-#' @param data data fram with colum `region` for each group, `Date` with dates and `total`, for fitting the growth rates
+#' Generate total cases graph
+#' @param data data fram with column `region` for each group, `Date` with dates and `total`, for fitting the growth rates
 #' @return a `ggplot` object
 #' @export
 total_graph <- function(data) {


### PR DESCRIPTION
Added inclusion of 2019 Population figures and ISO3C countryCodes.
Fixed typoes in documentation.

Rationale:
Keeping the 2019 Population figures around makes it possible to calculate per capita figures which are useful for some policy questions.
Keeping ISO3C countryCodes may make it possible to include flags or more simply filter by these (for those who think in terms of ISO3C country codes).